### PR TITLE
LO-CouplingCohesion: update to match the current codebase

### DIFF
--- a/docs/LearningOutcomes.adoc
+++ b/docs/LearningOutcomes.adoc
@@ -145,7 +145,7 @@ method in the child class should not reject `null` inputs. This will not be enfo
 
 == Analyze Coupling and Cohesion of designs `[LO-CouplingCohesion]`
 
-* Notice how having a separate `Formattter` class (an application of the Single Responsibility Principle) improves the _cohesion_ of the `MainWindow` class as well as the `Formatter` class.
+* Notice how having a separate `ParserUtil` class to handle user input validation, space trimming etc. of model data (an application of the Single Responsibility Principle) improves the _cohesion_ of the model component (since it does not need to be concerned with handling user input) as well as the `ParserUtil` class.
 
 === References
 


### PR DESCRIPTION
The LO references the `Formatter` class, which does not even exist in
the current codebase at all.

Instead, let's replace it with a completely new example of applying the
single responsibility principle in the current codebase -- the use of a
separate ParserUtil class for handling the parsing of model data.

While we are here, let's add some explanatory comments to make it clear
what the division of responsibilities between the model/parser layers
are.