### PR TITLE
Change travis build to use OpenJDK instead of Oracle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 matrix:
   include:
-    - jdk: oraclejdk11
+    - jdk: openjdk11
 
 script: >-
     ./config/travis/run-checks.sh &&


### PR DESCRIPTION
All builds with references to Oracle JDK11 breaks as Oracle appears
to be restricting headless downloads. Travis is also moving to remove
support for Oracle JDKs from install-jdk.sh

No work is required by students as their local builds on Oracle JDK
should behave similarly to OpenJDK.