### PR TITLE
docs: tell readers that the screenshots are meant for AB-4

### DIFF
--- a/docs/UsingAppVeyor.adoc
+++ b/docs/UsingAppVeyor.adoc
@@ -2,6 +2,15 @@
 :site-section: DeveloperGuide
 :imagesDir: images
 :stylesDir: stylesheets
+ifdef::env-github[]
+:note-caption: :information_source:
+endif::[]
+
+[NOTE]
+====
+This document was originally written for _AddressBook Level 4_ and hence its screenshots refer to `addressbook-level4`.
+For use with _AddressBook Level 3.5_, wherever `addressbook-level4` is used in the screenshots, you should use *`addressbook-level35`*.
+====
 
 https://www.appveyor.com/[AppVeyor] is a _Continuous Integration_ platform for GitHub projects. It runs its builds on Windows virtual machines.
 

--- a/docs/UsingCheckstyle.adoc
+++ b/docs/UsingCheckstyle.adoc
@@ -8,6 +8,12 @@ ifdef::env-github[]
 :note-caption: :information_source:
 endif::[]
 
+[NOTE]
+====
+This document was originally written for _AddressBook Level 4_ and hence its screenshots refer to `addressbook-level4`.
+For use with _AddressBook Level 3.5_, wherever `addressbook-level4` is used in the screenshots, you should use *`addressbook-level35`*.
+====
+
 == Configuring Checkstyle-IDEA
 
 . Install the Checkstyle-IDEA plugin by going to `File` > `Settings` (Windows/Linux), or `IntelliJ IDEA` > `Preferences...` (macOS). +

--- a/docs/UsingCoveralls.adoc
+++ b/docs/UsingCoveralls.adoc
@@ -2,6 +2,15 @@
 :site-section: DeveloperGuide
 :imagesDir: images
 :stylesDir: stylesheets
+ifdef::env-github[]
+:note-caption: :information_source:
+endif::[]
+
+[NOTE]
+====
+This document was originally written for _AddressBook Level 4_ and hence its screenshots refer to `addressbook-level4`.
+For use with _AddressBook Level 3.5_, wherever `addressbook-level4` is used in the screenshots, you should use *`addressbook-level35`*.
+====
 
 https://coveralls.io/[Coveralls] is a web service that tracks code coverage over time for GitHub projects.
 Coveralls requires Travis CI to be set up beforehand as Travis sends the coverage report from the latest build to Coveralls.

--- a/docs/UsingNetlify.adoc
+++ b/docs/UsingNetlify.adoc
@@ -2,6 +2,15 @@
 :site-section: DeveloperGuide
 :imagesDir: images
 :stylesDir: stylesheets
+ifdef::env-github[]
+:note-caption: :information_source:
+endif::[]
+
+[NOTE]
+====
+This document was originally written for _AddressBook Level 4_ and hence its screenshots refer to `addressbook-level4`.
+For use with _AddressBook Level 3.5_, wherever `addressbook-level4` is used in the screenshots, you should use *`addressbook-level35`*.
+====
 
 https://www.netlify.com/[Netlify] is an automated hosting platform for deploying static websites. With the aid of build tools such as Gradle, Netlify provides a smoother experience for previewing documentation. This can be done by using Netlify's https://www.netlify.com/blog/2016/07/20/introducing-deploy-previews-in-netlify/[Deploy Previews] feature, which shows a preview of the updated documentation whenever a pull request is made.
 

--- a/docs/UsingTravis.adoc
+++ b/docs/UsingTravis.adoc
@@ -2,6 +2,15 @@
 :site-section: DeveloperGuide
 :imagesDir: images
 :stylesDir: stylesheets
+ifdef::env-github[]
+:note-caption: :information_source:
+endif::[]
+
+[NOTE]
+====
+This document was originally written for _AddressBook Level 4_ and hence its screenshots refer to `addressbook-level4`.
+For use with _AddressBook Level 3.5_, wherever `addressbook-level4` is used in the screenshots, you should use *`addressbook-level35`*.
+====
 
 https://travis-ci.org/[Travis CI] is a _Continuous Integration_ platform for GitHub projects.
 


### PR DESCRIPTION
As the AB-3.5 repo inherited all of AB-4's documentation, it also
inherited their screenshots as well. However, these screenshots refer to
`addressbook-level4`, for use with the AB-4 repo, instead of
`addressbook-level35` which should be used with the AB-3.5 repo.

As such, let's add a note at the top of these documents informing
readers of this fact.

Yes, this means that readers would have to mentally replace all
references to `addressbook-level4` in the screenshots with
`addressbook-level35`, which could potentially confuse them. Ideally,
these screenshots should be modified to refer to `addressbook-level35`,
and the note should be added to the AB-4 repo instead. This is because
AB3.5 comes chronologically before AB-4, and readers would likely
encounter the documents in the AB-3.5 repo first and benefit most from
having clear unambiguous screenshots.

However, now is not a good time to update all the screenshots as the
AB-3.5 repo is still in flux. As such, let's settle for the note first,
with a plan to update the screenshots in the future.