### PR TITLE
Convert this repo into AB-3

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,10 +1,10 @@
-= Address Book (Level 3.5)
+= Address Book (Level 3)
 ifdef::env-github,env-browser[:relfileprefix: docs/]
 
-https://travis-ci.org/se-edu/addressbook-level35[image:https://travis-ci.org/se-edu/addressbook-level35.svg?branch=master[Build Status]]
-https://ci.appveyor.com/project/damithc/addressbook-level35[image:https://ci.appveyor.com/api/projects/status/3boko2x2vr5cc3w2?svg=true[Build status]]
-https://coveralls.io/github/se-edu/addressbook-level35?branch=master[image:https://coveralls.io/repos/github/se-edu/addressbook-level35/badge.svg?branch=master[Coverage Status]]
-https://www.codacy.com/app/damith/addressbook-level35?utm_source=github.com&utm_medium=referral&utm_content=se-edu/addressbook-level35&utm_campaign=Badge_Grade[image:https://api.codacy.com/project/badge/Grade/fc0b7775cf7f4fdeaf08776f3d8e364a[Codacy Badge]]
+https://travis-ci.org/se-edu/addressbook-level3[image:https://travis-ci.org/se-edu/addressbook-level3.svg?branch=master[Build Status]]
+https://ci.appveyor.com/project/damithc/addressbook-level3[image:https://ci.appveyor.com/api/projects/status/3boko2x2vr5cc3w2?svg=true[Build status]]
+https://coveralls.io/github/se-edu/addressbook-level3?branch=master[image:https://coveralls.io/repos/github/se-edu/addressbook-level3/badge.svg?branch=master[Coverage Status]]
+https://www.codacy.com/app/damith/addressbook-level3?utm_source=github.com&utm_medium=referral&utm_content=se-edu/addressbook-level3&utm_campaign=Badge_Grade[image:https://api.codacy.com/project/badge/Grade/fc0b7775cf7f4fdeaf08776f3d8e364a[Codacy Badge]]
 https://gitter.im/se-edu/Lobby[image:https://badges.gitter.im/se-edu/Lobby.svg[Gitter chat]]
 
 ifdef::env-github[]

--- a/build.gradle
+++ b/build.gradle
@@ -139,8 +139,8 @@ asciidoctor {
         idprefix: '',  // for compatibility with GitHub preview
         idseparator: '-',
         'site-root': "${sourceDir}",  // must be the same as sourceDir, do not modify
-        'site-name': 'AddressBook-Level3.5',
-        'site-githuburl': 'https://github.com/se-edu/addressbook-level35',
+        'site-name': 'AddressBook-Level3',
+        'site-githuburl': 'https://github.com/se-edu/addressbook-level3',
         'site-seedu': true,  // delete this line if your project is not a fork (not a SE-EDU project)
     ]
 

--- a/docs/AboutUs.adoc
+++ b/docs/AboutUs.adoc
@@ -4,7 +4,7 @@
 :imagesDir: images
 :stylesDir: stylesheets
 
-AddressBook - Level 3.5 was developed by the https://se-edu.github.io/docs/Team.html[se-edu] team. +
+AddressBook - Level 3 was developed by the https://se-edu.github.io/docs/Team.html[se-edu] team. +
 _{The dummy content given below serves as a placeholder to be used by future forks of the project.}_ +
 {empty} +
 We are a team based in the http://www.comp.nus.edu.sg[School of Computing, National University of Singapore].

--- a/docs/ContactUs.adoc
+++ b/docs/ContactUs.adoc
@@ -2,6 +2,6 @@
 :site-section: ContactUs
 :stylesDir: stylesheets
 
-* *Bug reports, Suggestions* : Post in our https://github.com/se-edu/addressbook-level35/issues[issue tracker] if you noticed bugs or have suggestions on how to improve.
+* *Bug reports, Suggestions* : Post in our https://github.com/se-edu/addressbook-level3/issues[issue tracker] if you noticed bugs or have suggestions on how to improve.
 * *Contributing* : We welcome pull requests. Follow the process described https://github.com/oss-generic/process[here]
 * *Email us* : You can also reach us at `damith [at] comp.nus.edu.sg`

--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -1,4 +1,4 @@
-= AddressBook Level 3.5 - Developer Guide
+= AddressBook Level 3 - Developer Guide
 :site-section: DeveloperGuide
 :toc:
 :toc-title:
@@ -12,7 +12,7 @@ ifdef::env-github[]
 :note-caption: :information_source:
 :warning-caption: :warning:
 endif::[]
-:repoURL: https://github.com/se-edu/addressbook-level35/tree/master
+:repoURL: https://github.com/se-edu/addressbook-level3/tree/master
 
 By: `Team SE-EDU`      Since: `Jun 2016`      Licence: `MIT`
 
@@ -64,9 +64,9 @@ Optionally, you can follow the <<UsingCheckstyle#, UsingCheckstyle.adoc>> docume
 
 ==== Updating documentation to match your fork
 
-After forking the repo, the documentation will still have the SE-EDU branding and refer to the `se-edu/addressbook-level35` repo.
+After forking the repo, the documentation will still have the SE-EDU branding and refer to the `se-edu/addressbook-level3` repo.
 
-If you plan to develop this fork as a separate product (i.e. instead of contributing to `se-edu/addressbook-level35`), you should do the following:
+If you plan to develop this fork as a separate product (i.e. instead of contributing to `se-edu/addressbook-level3`), you should do the following:
 
 . Configure the <<Docs-SiteWideDocSettings, site-wide documentation settings>> in link:{repoURL}/build.gradle[`build.gradle`], such as the `site-name`, to suit your own project.
 

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -1,4 +1,4 @@
-= AddressBook Level 3.5 - User Guide
+= AddressBook Level 3 - User Guide
 :site-section: UserGuide
 :toc:
 :toc-title:
@@ -12,13 +12,13 @@ ifdef::env-github[]
 :tip-caption: :bulb:
 :note-caption: :information_source:
 endif::[]
-:repoURL: https://github.com/se-edu/addressbook-level35
+:repoURL: https://github.com/se-edu/addressbook-level3
 
 By: `Team SE-EDU`      Since: `Jun 2016`      Licence: `MIT`
 
 == Introduction
 
-AddressBook Level 3.5 (AB3.5) is for those who *prefer to use a desktop app for managing contacts*. More importantly, AB3.5 is *optimized for those who prefer to work with a Command Line Interface* (CLI) while still having the benefits of a Graphical User Interface (GUI). If you can type fast, AB3.5 can get your contact management tasks done faster than traditional GUI apps. Interested? Jump to the <<Quick Start>> to get started. Enjoy!
+AddressBook Level 3 (AB3) is for those who *prefer to use a desktop app for managing contacts*. More importantly, AB3 is *optimized for those who prefer to work with a Command Line Interface* (CLI) while still having the benefits of a Graphical User Interface (GUI). If you can type fast, AB3 can get your contact management tasks done faster than traditional GUI apps. Interested? Jump to the <<Quick Start>> to get started. Enjoy!
 
 == Quick Start
 

--- a/docs/UsingAppVeyor.adoc
+++ b/docs/UsingAppVeyor.adoc
@@ -9,7 +9,7 @@ endif::[]
 [NOTE]
 ====
 This document was originally written for _AddressBook Level 4_ and hence its screenshots refer to `addressbook-level4`.
-For use with _AddressBook Level 3.5_, wherever `addressbook-level4` is used in the screenshots, you should use *`addressbook-level35`*.
+For use with _AddressBook Level 3_, wherever `addressbook-level4` is used in the screenshots, you should use *`addressbook-level3`*.
 ====
 
 https://www.appveyor.com/[AppVeyor] is a _Continuous Integration_ platform for GitHub projects. It runs its builds on Windows virtual machines.
@@ -88,7 +88,7 @@ Convert it to the asciidoc format as follows:
 The asciidoc code should look similar to:
 +
 ----
-https://ci.appveyor.com/project/damithc/addressbook-level35[image:https://ci.appveyor.com/api/projects/status/3boko2x2vr5cc3w2?svg=true[Build status]]
+https://ci.appveyor.com/project/damithc/addressbook-level3[image:https://ci.appveyor.com/api/projects/status/3boko2x2vr5cc3w2?svg=true[Build status]]
 ----
 +
 Copy and paste the asciidoc code to your `README.adoc` file.

--- a/docs/UsingCheckstyle.adoc
+++ b/docs/UsingCheckstyle.adoc
@@ -11,7 +11,7 @@ endif::[]
 [NOTE]
 ====
 This document was originally written for _AddressBook Level 4_ and hence its screenshots refer to `addressbook-level4`.
-For use with _AddressBook Level 3.5_, wherever `addressbook-level4` is used in the screenshots, you should use *`addressbook-level35`*.
+For use with _AddressBook Level 3_, wherever `addressbook-level4` is used in the screenshots, you should use *`addressbook-level3`*.
 ====
 
 == Configuring Checkstyle-IDEA

--- a/docs/UsingCoveralls.adoc
+++ b/docs/UsingCoveralls.adoc
@@ -9,7 +9,7 @@ endif::[]
 [NOTE]
 ====
 This document was originally written for _AddressBook Level 4_ and hence its screenshots refer to `addressbook-level4`.
-For use with _AddressBook Level 3.5_, wherever `addressbook-level4` is used in the screenshots, you should use *`addressbook-level35`*.
+For use with _AddressBook Level 3_, wherever `addressbook-level4` is used in the screenshots, you should use *`addressbook-level3`*.
 ====
 
 https://coveralls.io/[Coveralls] is a web service that tracks code coverage over time for GitHub projects.

--- a/docs/UsingNetlify.adoc
+++ b/docs/UsingNetlify.adoc
@@ -9,7 +9,7 @@ endif::[]
 [NOTE]
 ====
 This document was originally written for _AddressBook Level 4_ and hence its screenshots refer to `addressbook-level4`.
-For use with _AddressBook Level 3.5_, wherever `addressbook-level4` is used in the screenshots, you should use *`addressbook-level35`*.
+For use with _AddressBook Level 3_, wherever `addressbook-level4` is used in the screenshots, you should use *`addressbook-level3`*.
 ====
 
 https://www.netlify.com/[Netlify] is an automated hosting platform for deploying static websites. With the aid of build tools such as Gradle, Netlify provides a smoother experience for previewing documentation. This can be done by using Netlify's https://www.netlify.com/blog/2016/07/20/introducing-deploy-previews-in-netlify/[Deploy Previews] feature, which shows a preview of the updated documentation whenever a pull request is made.

--- a/docs/UsingTravis.adoc
+++ b/docs/UsingTravis.adoc
@@ -9,7 +9,7 @@ endif::[]
 [NOTE]
 ====
 This document was originally written for _AddressBook Level 4_ and hence its screenshots refer to `addressbook-level4`.
-For use with _AddressBook Level 3.5_, wherever `addressbook-level4` is used in the screenshots, you should use *`addressbook-level35`*.
+For use with _AddressBook Level 3_, wherever `addressbook-level4` is used in the screenshots, you should use *`addressbook-level3`*.
 ====
 
 https://travis-ci.org/[Travis CI] is a _Continuous Integration_ platform for GitHub projects.
@@ -110,7 +110,7 @@ Similarly, make sure you *do not print `$GITHUB_TOKEN` to the logs* in Travis sc
 .  Trigger Travis to regenerate documentation. To do so, you need to push a new commit to the master branch of the fork. +
    Suggested change: Remove the codacy badge from `README`.
 .  Wait for Travis CI to finish running the build on your new commit.
-.  Go to the URL `\https://<your-username-or-organization-name>.github.io/addressbook-level35/`. You should see your `README` file displayed.
+.  Go to the URL `\https://<your-username-or-organization-name>.github.io/addressbook-level3/`. You should see your `README` file displayed.
 
 == Repository-wide checks
 

--- a/docs/team/johndoe.adoc
+++ b/docs/team/johndoe.adoc
@@ -3,13 +3,13 @@
 :imagesDir: ../images
 :stylesDir: ../stylesheets
 
-== PROJECT: AddressBook - Level 3.5
+== PROJECT: AddressBook - Level 3
 
 ---
 
 == Overview
 
-AddressBook - Level 3.5 is a desktop address book application used for teaching Software Engineering principles. The user interacts with it using a CLI, and it has a GUI created with JavaFX. It is written in Java, and has about 10 kLoC.
+AddressBook - Level 3 is a desktop address book application used for teaching Software Engineering principles. The user interacts with it using a CLI, and it has a GUI created with JavaFX. It is written in Java, and has about 10 kLoC.
 
 == Summary of contributions
 

--- a/docs/templates/_header.html.slim
+++ b/docs/templates/_header.html.slim
@@ -11,9 +11,9 @@
           li.nav-item
             a.nav-link href='https://se-edu.github.io/addressbook-level2' AB-2
           li.nav-item
-            a.nav-link href='https://se-edu.github.io/addressbook-level3' AB-3
-          li.nav-item
             a.nav-link.active href=(site_url 'index.html') AB-3.5
+          li.nav-item
+            a.nav-link href='https://se-edu.github.io/addressbook-level4' AB-4
           li.nav-item
             a.nav-link href='https://se-edu.github.io/collate' Collate
           li.nav-item

--- a/docs/templates/_header.html.slim
+++ b/docs/templates/_header.html.slim
@@ -11,7 +11,7 @@
           li.nav-item
             a.nav-link href='https://se-edu.github.io/addressbook-level2' AB-2
           li.nav-item
-            a.nav-link.active href=(site_url 'index.html') AB-3.5
+            a.nav-link.active href=(site_url 'index.html') AB-3
           li.nav-item
             a.nav-link href='https://se-edu.github.io/addressbook-level4' AB-4
           li.nav-item


### PR DESCRIPTION
Fixes #2 

```
Convert this repo into the new AB-3 repo.

Compared to the old AB-3, this repo is derived from the AB-4 codebase,
and thus shares all of its improvements, and allows us to more easily
port over changes from AB-4 in the future.
```