### PR TITLE
Add Tutorials to header in documentation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ asciidoctor {
         idprefix: '',  // for compatibility with GitHub preview
         idseparator: '-',
         'site-root': "${sourceDir}",  // must be the same as sourceDir, do not modify
-        'site-name': 'AddressBook-Level3',
+        'site-name': 'AB-3',
         'site-githuburl': 'https://github.com/se-edu/addressbook-level3',
         'site-seedu': true,  // delete this line if your project is not a fork (not a SE-EDU project)
     ]

--- a/docs/Tutorials.adoc
+++ b/docs/Tutorials.adoc
@@ -1,0 +1,11 @@
+= Tutorials
+:site-section: Tutorials
+:stylesDir: stylesheets
+
+You might find it helpful to work through some of these tutorials before contributing to AddressBook.
+
+[cols="2,3", options="header"]
+|===
+|Title|Description
+|<<tutorials/TracingCode#, Tracing a Command Execution Path>>| Learn about the architecture of AddressBook and how various components work together
+|<<tutorials/RemovingFields#, Removing a field from an entity>> | Explore and apply automated refactoring tools

--- a/docs/templates/_header.html.slim
+++ b/docs/templates/_header.html.slim
@@ -35,6 +35,9 @@
           - if attr? 'site-seedu'
             li.nav-item
               =nav_link('LearningOutcomes', 'LearningOutcomes.html', 'LOs')
+          - if attr? 'site-seedu'
+            li.nav-item
+              = nav_link('Tutorials', 'Tutorials.html', 'Tutorials')
           li.nav-item
             =nav_link('AboutUs', 'AboutUs.html', 'About Us')
           li.nav-item


### PR DESCRIPTION
Without a direct link to the tutorials, students find it hard to access
them. To improve ease of access to the tutorials, we add a new
Tutorials category to the navigation bar in the document.

Also, we shorten the site-name to 'AB-3' to maintain the length of the navbar
on common viewports.