### PR TITLE
Display page title

### DIFF
--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -7,4 +7,6 @@
 
   {%- include custom-head.html -%}
 
+  <title>{{page.title}}</title>
+
 </head>


### PR DESCRIPTION
Fixes #44 

The `<title>` tag's value is now set to the `title` attribute of each page. 
A live preview is available [here](https://j-lum.github.io/addressbook-level3/).