### PR TITLE
Change IDEA codestyle href

### DIFF
--- a/docs/SettingUp.md
+++ b/docs/SettingUp.md
@@ -32,7 +32,7 @@ If you plan to use Intellij IDEA (highly recommended):
 
 1. **Configure the coding style**
 
-   If using IDEA, follow the guide [_[se-edu/guides] IDEA: Configuring the code style_](https://se-education.org/guides/tutorials/checkstyle.html) to set up IDEA's coding style to match ours.
+   If using IDEA, follow the guide [_[se-edu/guides] IDEA: Configuring the code style_](https://se-education.org/guides/tutorials/intellijCodeStyle.html) to set up IDEA's coding style to match ours.
 
    <div markdown="span" class="alert alert-primary">:bulb: **Tip:**
 


### PR DESCRIPTION
On the "Setting up and getting started" page of AB3 developer guide (https://nus-cs2103-ay2021s1.github.io/tp/SettingUp.html), the href for "[se-edu/guides] IDEA: Configuring the JDK" is pointed towards https://se-education.org/guides/tutorials/checkstyle.html, instead of https://se-education.org/guides/tutorials/intellijCodeStyle.html
