### PR TITLE
Update Checkout action default branch

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Set up repository
-        uses: actions/checkout@master
+        uses: actions/checkout@main
 
       - name: Set up repository
-        uses: actions/checkout@master
+        uses: actions/checkout@main
         with:
           ref: master
 


### PR DESCRIPTION
Fixes #47 

The warning is showing because the [checkout actions repo](https://github.com/actions/checkout) itself has renamed its default branch from `master` to `main`: https://github.com/actions/checkout/branches

Let's fix this by updating the CI workflow to use `actions/checkout@main` instead of `actions/checkout@master`.

I've done a test PR on my own fork to verify that the warning no longer appears: https://github.com/wltan/addressbook-level3/pull/1