### PR TITLE
Update checking for Duplicates in EditCommand (Follow up from #68)

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -77,10 +77,13 @@ public class EditCommand extends Command {
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
-        if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
+        model.deletePerson(personToEdit);
+        if (model.hasPerson(editedPerson)) {
+            model.addPerson(index.getZeroBased(), personToEdit);
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
+        model.addPerson(index.getZeroBased(), personToEdit);
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -75,6 +75,14 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Adds a person to the address book at a specified index.
+     * The person must not already exist in the address book.
+     */
+    public void addPerson(int index, Person p) {
+        persons.add(index, p);
+    }
+
+    /**
      * Replaces the given person {@code target} in the list with {@code editedPerson}.
      * {@code target} must exist in the address book.
      * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -70,6 +70,12 @@ public interface Model {
     void addPerson(Person person);
 
     /**
+     * Adds the given person at a specified index.
+     * {@code person} must not already exist in the address book.
+     */
+    void addPerson(int index, Person person);
+
+    /**
      * Replaces the given person {@code target} with {@code editedPerson}.
      * {@code target} must exist in the address book.
      * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -105,6 +105,10 @@ public class ModelManager implements Model {
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
+    public void addPerson(int index, Person person) {
+        addressBook.addPerson(index, person);
+    }
+
     @Override
     public void setPerson(Person target, Person editedPerson) {
         requireAllNonNull(target, editedPerson);

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -49,6 +49,18 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
+     * Adds a person to the list at a specified index.
+     * The person must not already exist in the list.
+     */
+    public void add(int index, Person toAdd) {
+        requireNonNull(toAdd);
+        if (contains(toAdd)) {
+            throw new DuplicatePersonException();
+        }
+        internalList.add(index, toAdd);
+    }
+
+    /**
      * Replaces the person {@code target} in the list with {@code editedPerson}.
      * {@code target} must exist in the list.
      * The person identity of {@code editedPerson} must not be the same as another existing person in the list.

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -114,6 +114,12 @@ public class AddCommandTest {
         }
 
         @Override
+        public void addPerson(int index, Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+
+        @Override
         public void setAddressBook(ReadOnlyAddressBook newData) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -4,7 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
@@ -117,6 +120,55 @@ public class EditCommandTest {
                 new EditPersonDescriptorBuilder(personInList).build());
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+    }
+
+    @Test
+    public void execute_duplicateNameUnfilteredList_otherIdentityFieldsDifferent() {
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+        // edit second person to first person name with different valid fields -> success
+        EditCommand editPersonNameCommand = new EditCommand(INDEX_SECOND_PERSON,
+                new EditPersonDescriptorBuilder(firstPerson).withPhone(VALID_PHONE_AMY)
+                        .withEmail(VALID_EMAIL_AMY).build());
+        Person editedPerson = new PersonBuilder(firstPerson).withPhone(VALID_PHONE_AMY)
+                .withEmail(VALID_EMAIL_AMY).build();
+        String expectedFirstMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(1), editedPerson);
+
+        assertCommandSuccess(editPersonNameCommand, model, expectedFirstMessage, expectedModel);
+
+        // edit first person to have duplicate phone -> failure
+        EditCommand editPhoneCommand = new EditCommand(INDEX_FIRST_PERSON,
+                new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_AMY).build());
+        assertCommandFailure(editPhoneCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+
+        // edit first person to have duplicate email -> failure
+        EditCommand editEmailCommand = new EditCommand(INDEX_FIRST_PERSON,
+                new EditPersonDescriptorBuilder().withEmail(VALID_EMAIL_AMY).build());
+        assertCommandFailure(editEmailCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
+    }
+
+    @Test
+    public void execute_duplicateFieldsUnfilteredList_nameMustBeDifferent() {
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+        //edit second person to first person with a different valid name -> success
+        EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON,
+                new EditPersonDescriptorBuilder(firstPerson).withName(VALID_NAME_AMY).build());
+        Person editedPerson = new PersonBuilder(firstPerson).withName(VALID_NAME_AMY).build();
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(1), editedPerson);
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+
+        //edit first person to have a duplicate name -> failure
+        EditCommand editNameCommand = new EditCommand(INDEX_FIRST_PERSON,
+                new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY).build());
+        assertCommandFailure(editNameCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
     }
 
     @Test


### PR DESCRIPTION
Follow up from #68 

Let's
* remove the target `personToEdit` from the model
* add the `Person` back to its original position in the `AddressBook` after the check
* extend the functionality of the Model to add a `Person` at a specified `index`, it should also not update the filtered person list

The `UniquePersonList` in `AddressBook` currently does not support adding a Person at a specified position, however, it is needed for the check as we have to add back the deleted `personToEdit` to restore the exact internal list.

The overloaded `addPerson(int index, Person person)` should not update the filtered list as it will be used in cases where there are duplicates and an exception is returned. The filtered list do not need to be updated here.