### PR TITLE
Page breaks cut through content when converted to PDF #59

### DIFF
--- a/docs/_sass/minima/_base.scss
+++ b/docs/_sass/minima/_base.scss
@@ -270,3 +270,12 @@ table {
             -ms-overflow-style: -ms-autohiding-scrollbar;
   }
 }
+
+/**
+ * Prevents page break to cut through content when converting to pdf
+ */
+@media print {
+  body {
+    display: block;
+  }
+}


### PR DESCRIPTION
Fixes #59 

The page breaks cut through content if no specific media query is specified

Let's fix this by applying the media print query `break-inside: avoid` on body elements 

I've tested this on my 2103 team's UG and on AB3 to verify the fix