### PR TITLE
Omit navbar of printed pdf for UG and DG

### DIFF
--- a/docs/_sass/minima/_base.scss
+++ b/docs/_sass/minima/_base.scss
@@ -271,6 +271,9 @@ table {
   }
 }
 
+/**
+ * Hides the navigation bar when converting to pdf
+ */
 @media print {
    .site-header {
      display: none;

--- a/docs/_sass/minima/_base.scss
+++ b/docs/_sass/minima/_base.scss
@@ -270,3 +270,9 @@ table {
             -ms-overflow-style: -ms-autohiding-scrollbar;
   }
 }
+
+@media print {
+   .site-header {
+     display: none;
+   }
+ }


### PR DESCRIPTION
Fixes #35 

Let's add a media query for printing, to hide the navigation bar by setting the display to none.