### PR TITLE
Print to pdf displays navigation bar above pages

### DIFF
--- a/docs/_sass/minima/_base.scss
+++ b/docs/_sass/minima/_base.scss
@@ -271,11 +271,25 @@ table {
   }
 }
 
-/**
- * Prevents page break to cut through content when converting to pdf
- */
 @media print {
+  /**
+  * Prevents page break from cutting through content when printing
+  */
   body {
     display: block;
   }
+  /**
+  * Replaces the top navigation menu with the project name when printing
+  */
+  .site-header .wrapper {
+    display: none;
+  }
+  .site-header {
+    text-align: center;
+  }
+  .site-header:before {
+    content: "AB-3";
+    font-size: 32px;
+  }
 }
+


### PR DESCRIPTION
Fixes #35 

Navigation bar is not necessary and clutters the pdf pages

Adding a css print query will allow for the pages to be
printed out without showing the navigation bar

Let's specify the behaviour of the media print query
to change the display type of the site-header component,
which contains the navigation bar, to none

We found this fix to be the most suitable as
it only modifies the body content when
printing the document