### PR TITLE
Update Ui of help window to dark theme

### DIFF
--- a/src/main/resources/view/HelpWindow.css
+++ b/src/main/resources/view/HelpWindow.css
@@ -1,3 +1,20 @@
 #copyButton, #helpMessage {
     -fx-font-family: "Open Sans";
+    -fx-text-fill: white;
+}
+
+#copyButton {
+    -fx-background-color: dimgray;
+}
+
+#copyButton:hover {
+    -fx-background-color: gray;
+}
+
+#copyButton:armed {
+    -fx-background-color: darkgray;
+}
+
+#helpMessageContainer {
+    -fx-background-color: derive(#1d1d1d, 20%);
 }

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -20,7 +20,7 @@
         <URL value="@HelpWindow.css" />
       </stylesheets>
 
-      <HBox alignment="CENTER">
+      <HBox alignment="CENTER" fx:id="helpMessageContainer">
         <children>
           <Label fx:id="helpMessage" text="Label">
             <HBox.margin>


### PR DESCRIPTION
Fixes #107 

> A proposed fix would be to import the same stylesheets used by the main window into the help window, since elements should all look similar regardless of the window type. 

Since HelpWindow has its own dedicated CSS file, it will make more sense to edit it instead of importing the same stylesheets used by main window also it doesn't work simply to import the main window's stylesheet.

> An alternative would be to have a dedicated stylesheet for the help window that inherits most of the dark theme styles to allow for independent customisation.

Personally, I feel that there isn't much UI involved in AB3 itself, so it feels a bit unnecessary to do such an abstraction. In fact, it can be encouraged for the students who plan to so as an extra improvement when taking over it as a brownfield project.

Small Changes to HelpWindow's UI to fit the DarkTheme
![Screenshot 2021-12-04 at 1 42 57 AM](https://user-images.githubusercontent.com/65809727/144649532-42b61d0d-b06c-4d92-916a-154004073c7e.png)
