### PR TITLE
Add wildcard parameterized type

### DIFF
--- a/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
+++ b/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
@@ -14,7 +14,8 @@ public class CommandParserTestUtil {
      * Asserts that the parsing of {@code userInput} by {@code parser} is successful and the command created
      * equals to {@code expectedCommand}.
      */
-    public static void assertParseSuccess(Parser parser, String userInput, Command expectedCommand) {
+    public static void assertParseSuccess(Parser<? extends Command> parser, String userInput,
+            Command expectedCommand) {
         try {
             Command command = parser.parse(userInput);
             assertEquals(expectedCommand, command);
@@ -27,7 +28,7 @@ public class CommandParserTestUtil {
      * Asserts that the parsing of {@code userInput} by {@code parser} is unsuccessful and the error message
      * equals to {@code expectedMessage}.
      */
-    public static void assertParseFailure(Parser parser, String userInput, String expectedMessage) {
+    public static void assertParseFailure(Parser<? extends Command> parser, String userInput, String expectedMessage) {
         try {
             parser.parse(userInput);
             throw new AssertionError("The expected ParseException was not thrown.");


### PR DESCRIPTION
Part of #122 

Proposed commit message:
```
The assertParseSuccess and assertParseFailure parameter parser
uses raw type for Parser. This would give a warning under to 
javac -Xlint:rawtypes.

Let's add a wildcard type parameter to Parser.
```

![Screenshot (68)](https://user-images.githubusercontent.com/69678785/152357330-3bf44110-51b3-4063-a63c-0467e713f55e.png)
