### PR TITLE
gradle.yml: Upgrade Codecov Action

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -38,8 +38,9 @@ jobs:
       - name: Build and check with Gradle
         run: ./gradlew check coverage
 
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         if: runner.os == 'Linux'
         with:
-          file: ${{ github.workspace }}/build/reports/jacoco/coverage/coverage.xml
+          directory: ${{ github.workspace }}/build/reports/jacoco/coverage
+          files: coverage.xml
           fail_ci_if_error: true


### PR DESCRIPTION
Fixes #127 

Proposed Commit Message:
```
Codecov GitHub Action v1 uses a deprecated bash uploader, which may
cease to function soon. The v2 version also has a files arg instead of a
file arg, suggesting possible deprecation of the file arg.

Let's upgrade to v2, use the files arg for coverage.xml and the directory
arg for the directory in which coverage.xml is found.

```