### PR TITLE
Upgrade Checkstyle to 10.2 and update checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 }
 
 checkstyle {
-    toolVersion = '8.29'
+    toolVersion = '10.2'
 }
 
 test {

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -376,12 +376,12 @@
     JAVADOC CHECKS
     -->
 
-    <!-- Checks that every class, enumeration and interface have a header comment. -->
+    <!-- Checks the Javadoc's format for every class, enumeration and interface. -->
     <module name="JavadocType">
       <property name="allowMissingParamTags" value="true"/>
     </module>
 
-    <!-- Checks that every public method (excluding getters, setters and constructors) has a header comment. -->
+    <!-- Checks the Javadoc's format for every public method (excluding getters, setters and constructors). -->
     <module name="JavadocMethod">
       <property name="allowedAnnotations" value="Override, Test, BeforeAll, BeforeEach, AfterAll, AfterEach, Subscribe"/>
       <property name="accessModifiers" value="public"/>
@@ -393,6 +393,7 @@
 
     <module name="InvalidJavadocPosition"/>
 
+    <!-- Checks that every public method (excluding getters, setters and constructors) has a header comment. -->
     <module name="MissingJavadocMethodCheck">
       <property name="minLineCount" value="1"/>
       <property name="allowMissingPropertyJavadoc" value="true"/>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -4,8 +4,8 @@
     "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!--
-    This configuration file enforces rules for a modified version of the module's code standard at
-    https://oss-generic.github.io/process/codingstandards/coding-standards-java.html
+    This configuration file enforces rules for the coding standard at
+    https://se-education.org/guides/conventions/java/intermediate.html
 -->
 
 <module name="Checker">

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -245,6 +245,9 @@
     -->
     <module name ="DeclarationOrder"/>
 
+    <!-- Checks that default is after all cases in a switch statement -->
+    <module name="DefaultComesLast"/>
+
     <module name="ModifierOrder">
       <!-- Warn if modifier order is inconsistent with JLS3 8.1.1, 8.3.1, and
            8.4.3.  The prescribed order is:
@@ -340,6 +343,7 @@
 
     <module name="Indentation">
       <property name="caseIndent" value="0" />
+      <property name="throwsIndent" value="8" />
     </module>
 
     <module name="NoWhitespaceBefore">
@@ -347,6 +351,11 @@
       <property name="tokens" value="SEMI, DOT, POST_DEC, POST_INC"/>
       <property name="allowLineBreaks" value="true"/>
     </module>
+
+    <module name="NoWhitespaceBeforeCaseDefaultColon"/>
+
+    <!-- Checks that there is no whitespace between method/constructor name and open parenthesis. -->
+    <module name="MethodParamPad"/>
 
     <module name="ParenPad">
       <!-- Checks that there is no whitespace before close parenthesis or after open parenthesis. -->
@@ -376,6 +385,24 @@
     JAVADOC CHECKS
     -->
 
+    <!-- Checks that all block-tags are ordered correctly. -->
+    <module name="AtclauseOrder"/>
+
+    <!-- Checks that Javadoc block tags appear only at the beginning of the line. -->
+    <module name="JavadocBlockTagLocation"/>
+
+    <!-- Checks that all Javadoc comments start from the second line. -->
+    <module name="JavadocContentLocationCheck" />
+
+    <!-- Checks that each line in Javadoc has leading asterisks. -->
+    <module name="JavadocMissingLeadingAsterisk"/>
+
+    <!-- Checks that each non-empty line in Javadoc has whitespace after leading asterisk. -->
+    <module name="JavadocMissingWhitespaceAfterAsterisk"/>
+
+    <!-- Checks that for block tags, indentation of continuation lines is at least 4 spaces. -->
+    <module name="JavadocTagContinuationIndentation"/>
+
     <!-- Checks the Javadoc's format for every class, enumeration and interface. -->
     <module name="JavadocType">
       <property name="allowMissingParamTags" value="true"/>
@@ -399,6 +426,9 @@
       <property name="allowMissingPropertyJavadoc" value="true"/>
       <property name="ignoreMethodNamesRegex" value="(set.*|get.*)"/>
     </module>
+
+    <!-- Checks that every public class, enumeration and interface has a header comment. -->
+    <module name="MissingJavadocType"/>
 
   </module>
 </module>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -384,7 +384,7 @@
     <!-- Checks that every public method (excluding getters, setters and constructors) has a header comment. -->
     <module name="JavadocMethod">
       <property name="allowedAnnotations" value="Override, Test, BeforeAll, BeforeEach, AfterAll, AfterEach, Subscribe"/>
-      <property name="scope" value="public"/>
+      <property name="accessModifiers" value="public"/>
       <property name="validateThrows" value="false"/>
       <property name="allowMissingParamTags" value="true"/>
       <property name="allowMissingReturnTag" value="true"/>

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -47,20 +47,20 @@ public class HelpWindow extends UiPart<Stage> {
     /**
      * Shows the help window.
      * @throws IllegalStateException
-     * <ul>
-     *     <li>
-     *         if this method is called on a thread other than the JavaFX Application Thread.
-     *     </li>
-     *     <li>
-     *         if this method is called during animation or layout processing.
-     *     </li>
-     *     <li>
-     *         if this method is called on the primary stage.
-     *     </li>
-     *     <li>
-     *         if {@code dialogStage} is already showing.
-     *     </li>
-     * </ul>
+     *     <ul>
+     *         <li>
+     *             if this method is called on a thread other than the JavaFX Application Thread.
+     *         </li>
+     *         <li>
+     *             if this method is called during animation or layout processing.
+     *         </li>
+     *         <li>
+     *             if this method is called on the primary stage.
+     *         </li>
+     *         <li>
+     *             if {@code dialogStage} is already showing.
+     *         </li>
+     *     </ul>
      */
     public void show() {
         logger.fine("Showing help page about the application.");


### PR DESCRIPTION
Fixes #124 

There is one additional check that I wanted to implement: [RequireEmptyLineBeforeBlockTagGroup](https://checkstyle.sourceforge.io/config_javadoc.html#RequireEmptyLineBeforeBlockTagGroup). However, this particular line will fail the check:
https://github.com/se-edu/addressbook-level3/blob/865de62540a50cf0690abc36a212eea1e0b4617a/src/main/java/seedu/address/commons/util/CollectionUtil.java#L15-L16

The problem here is that `@see` is treated like any other block tag despite this particular method having no Javadoc description of its own. 