### PR TITLE
[#173] Null class logger not logging to logger output

### DIFF
--- a/src/main/java/seedu/address/commons/core/LogsCenter.java
+++ b/src/main/java/seedu/address/commons/core/LogsCenter.java
@@ -1,5 +1,7 @@
 package seedu.address.commons.core;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.logging.ConsoleHandler;
@@ -53,9 +55,7 @@ public class LogsCenter {
      * Creates a Logger for the given class name.
      */
     public static <T> Logger getLogger(Class<T> clazz) {
-        if (clazz == null) {
-            return Logger.getLogger("");
-        }
+        requireNonNull(clazz);
         return getLogger(clazz.getSimpleName());
     }
 


### PR DESCRIPTION
Fixes #173 

There is a check when a null class logger is created. 
However, AB3 currently do not actually use null class loggers.

Let's replace the null class check with assertion instead as per YAGNI principe.