### PR TITLE
[#171] Updating gitignore to account for bin folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Gradle build files
 /.gradle/
 /build/
+/bin/
 src/main/resources/docs/
 
 # IDEA files


### PR DESCRIPTION
Fixes #171 

Previously, running the command `./gradlew` generated a bin folder containing all the .class files.
To prevent accidentally committing files to the repository, let's adds /bin/ to the .gitignore file