### PR TITLE
[#166] Bump javafx to version 11.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ task coverage(type: JacocoReport) {
 
 dependencies {
     String jUnitVersion = '5.4.0'
-    String javaFxVersion = '11'
+    String javaFxVersion = '11.0.2'
 
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'win'
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'mac'


### PR DESCRIPTION
Fixes #166 

Conflict between JavaFx version 11 and Ubuntu 18.04 and above described in JDK-8210411 presents a compatibility issue for users using Ubuntu 18.04 and above. This fatal crash also causes JVM to generate a hs_err_pid log file.

This issue is fixed in JavaFx version 11.0.2. Let's bump JavaFx to the appropriate version to avoid this issue.

