### PR TITLE
[#178] Include JVM Crash Logs in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ src/main/resources/docs/
 /config.json
 /preferences.json
 /*.log.*
+hs_err_pid[0-9]*.log
 
 # Test sandbox files
 src/test/data/sandbox/


### PR DESCRIPTION
Fixes #178 

hs_err_pid files are being generated by JVM when a fatal error occurs.

These files should not be pushed to the repository.

Let's add hs_err_pid[0-9]*.log to gitignore.