### PR TITLE
[#183] Inconsistency between GitHub file preview and GitHub Page

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,7 +6,7 @@ header_pages:
   - DeveloperGuide.md
   - AboutUs.md
 
-markdown: kramdown
+markdown: GFM
 
 repository: "se-edu/addressbook-level3"
 github_icon: "images/github-icon.png"


### PR DESCRIPTION
Fixes #183 

The use of differing markdown renderer in Github pages causes certain tables that can be displayed properly in Github to appear jumbled in Github pages.

To ensure consistent rendering between GitHub markdown and the markdown in Gtihub pages,
Let's replace the kramdown markdown renderer with GFM in _config.yml.