### PR TITLE
[#167] Unnecessary catch block in MainApp and Exceptions in Interfaces

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -84,11 +84,12 @@ public class MainApp extends Application {
             }
             initialData = addressBookOptional.orElseGet(SampleDataUtil::getSampleAddressBook);
         } catch (DataConversionException e) {
-            logger.warning("Data file at " + storage.getAddressBookFilePath() + " is not in the correct format."
+            logger.warning("Data file at " + storage.getAddressBookFilePath()
+                    + " is might be corrupted or in the wrong format."
                     + " Will be starting with an empty AddressBook.");
             initialData = new AddressBook();
         } catch (IOException e) {
-            logger.warning("Problem while reading from the file " + storage.getAddressBookFilePath()
+            logger.warning("Problem while reading from the data file " + storage.getAddressBookFilePath()
                     + ". Will be starting with an empty AddressBook.");
             initialData = new AddressBook();
         }
@@ -106,10 +107,7 @@ public class MainApp extends Application {
      * if {@code configFilePath} is null.
      */
     protected Config initConfig(Path configFilePath) {
-        Config initializedConfig;
-        Path configFilePathUsed;
-
-        configFilePathUsed = Config.DEFAULT_CONFIG_FILE;
+        Path configFilePathUsed = Config.DEFAULT_CONFIG_FILE;
 
         if (configFilePath != null) {
             logger.info("Custom Config file specified " + configFilePath);
@@ -117,18 +115,22 @@ public class MainApp extends Application {
         }
 
         logger.info("Using config file : " + configFilePathUsed);
-
+        Optional<Config> configOptional = Optional.empty();
         try {
-            Optional<Config> configOptional = ConfigUtil.readConfig(configFilePathUsed);
+            configOptional = ConfigUtil.readConfig(configFilePathUsed);
             if (!configOptional.isPresent()) {
                 logger.info("Creating new config file " + configFilePathUsed);
             }
-            initializedConfig = configOptional.orElse(new Config());
         } catch (DataConversionException e) {
-            logger.warning("Config file at " + configFilePathUsed + " is not in the correct format."
-                    + " Using default config properties.");
-            initializedConfig = new Config();
+            logger.warning("Config file at " + configFilePathUsed
+                    + " might be corrupted or in the wrong format"
+                    + ". Using default config properties.");
+        } catch (IOException e) {
+            logger.warning("Problem while reading from the config file " + configFilePathUsed
+                    + ". Using default config properties.");
         }
+
+        Config initializedConfig = configOptional.orElse(new Config());
 
         //Update config file in case it was missing to begin with or there are new/unused fields
         try {
@@ -148,22 +150,20 @@ public class MainApp extends Application {
         Path prefsFilePath = storage.getUserPrefsFilePath();
         logger.info("Using preference file : " + prefsFilePath);
 
-        UserPrefs initializedPrefs;
+        Optional<UserPrefs> prefsOptional = Optional.empty();
         try {
-            Optional<UserPrefs> prefsOptional = storage.readUserPrefs();
+            prefsOptional = storage.readUserPrefs();
             if (!prefsOptional.isPresent()) {
                 logger.info("Creating new preference file " + prefsFilePath);
             }
-            initializedPrefs = prefsOptional.orElse(new UserPrefs());
         } catch (DataConversionException e) {
-            logger.warning("Preference file at " + prefsFilePath + " is not in the correct format."
+            logger.warning("Preference file at " + prefsFilePath + " might be corrupted or in the wrong format."
                     + " Using default preferences.");
-            initializedPrefs = new UserPrefs();
         } catch (IOException e) {
             logger.warning("Problem while reading from preference file " + prefsFilePath
-                    + ". Will be starting with an empty AddressBook.");
-            initializedPrefs = new UserPrefs();
+                    + ". Using default preferences");
         }
+        UserPrefs initializedPrefs = prefsOptional.orElse(new UserPrefs());
 
         //Update prefs file in case it was missing to begin with or there are new/unused fields
         try {

--- a/src/main/java/seedu/address/commons/util/ConfigUtil.java
+++ b/src/main/java/seedu/address/commons/util/ConfigUtil.java
@@ -12,7 +12,7 @@ import seedu.address.commons.exceptions.DataConversionException;
  */
 public class ConfigUtil {
 
-    public static Optional<Config> readConfig(Path configFilePath) throws DataConversionException {
+    public static Optional<Config> readConfig(Path configFilePath) throws DataConversionException, IOException {
         return JsonUtil.readJsonFile(configFilePath, Config.class);
     }
 

--- a/src/main/java/seedu/address/commons/util/JsonUtil.java
+++ b/src/main/java/seedu/address/commons/util/JsonUtil.java
@@ -55,8 +55,8 @@ public class JsonUtil {
      * @param classOfObjectToDeserialize Json file has to correspond to the structure in the class given here.
      * @throws DataConversionException if the file format is not as expected.
      */
-    public static <T> Optional<T> readJsonFile(
-            Path filePath, Class<T> classOfObjectToDeserialize) throws DataConversionException {
+    public static <T> Optional<T> readJsonFile(Path filePath, Class<T> classOfObjectToDeserialize)
+            throws DataConversionException, IOException {
         requireNonNull(filePath);
 
         if (!Files.exists(filePath)) {
@@ -68,9 +68,12 @@ public class JsonUtil {
 
         try {
             jsonFile = deserializeObjectFromJsonFile(filePath, classOfObjectToDeserialize);
+        } catch (JsonProcessingException e) {
+            logger.warning("Error processing data from jsonFile file " + filePath + ": " + e);
+            throw new DataConversionException(e);
         } catch (IOException e) {
             logger.warning("Error reading from jsonFile file " + filePath + ": " + e);
-            throw new DataConversionException(e);
+            throw e;
         }
 
         return Optional.of(jsonFile);
@@ -96,7 +99,8 @@ public class JsonUtil {
      * @param <T> The generic type to create an instance of
      * @return The instance of T with the specified values in the JSON string
      */
-    public static <T> T fromJsonString(String json, Class<T> instanceClass) throws IOException {
+    public static <T> T fromJsonString(String json, Class<T> instanceClass)
+            throws IOException, JsonProcessingException {
         return objectMapper.readValue(json, instanceClass);
     }
 

--- a/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
@@ -32,7 +32,7 @@ public class JsonAddressBookStorage implements AddressBookStorage {
     }
 
     @Override
-    public Optional<ReadOnlyAddressBook> readAddressBook() throws DataConversionException {
+    public Optional<ReadOnlyAddressBook> readAddressBook() throws DataConversionException, IOException {
         return readAddressBook(filePath);
     }
 
@@ -42,7 +42,7 @@ public class JsonAddressBookStorage implements AddressBookStorage {
      * @param filePath location of the data. Cannot be null.
      * @throws DataConversionException if the file is not in the correct format.
      */
-    public Optional<ReadOnlyAddressBook> readAddressBook(Path filePath) throws DataConversionException {
+    public Optional<ReadOnlyAddressBook> readAddressBook(Path filePath) throws DataConversionException, IOException {
         requireNonNull(filePath);
 
         Optional<JsonSerializableAddressBook> jsonAddressBook = JsonUtil.readJsonFile(

--- a/src/main/java/seedu/address/storage/JsonUserPrefsStorage.java
+++ b/src/main/java/seedu/address/storage/JsonUserPrefsStorage.java
@@ -26,7 +26,7 @@ public class JsonUserPrefsStorage implements UserPrefsStorage {
     }
 
     @Override
-    public Optional<UserPrefs> readUserPrefs() throws DataConversionException {
+    public Optional<UserPrefs> readUserPrefs() throws DataConversionException, IOException {
         return readUserPrefs(filePath);
     }
 
@@ -35,7 +35,7 @@ public class JsonUserPrefsStorage implements UserPrefsStorage {
      * @param prefsFilePath location of the data. Cannot be null.
      * @throws DataConversionException if the file format is not as expected.
      */
-    public Optional<UserPrefs> readUserPrefs(Path prefsFilePath) throws DataConversionException {
+    public Optional<UserPrefs> readUserPrefs(Path prefsFilePath) throws DataConversionException, IOException {
         return JsonUtil.readJsonFile(prefsFilePath, UserPrefs.class);
     }
 

--- a/src/test/java/seedu/address/commons/util/ConfigUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/ConfigUtilTest.java
@@ -29,7 +29,7 @@ public class ConfigUtilTest {
     }
 
     @Test
-    public void read_missingFile_emptyResult() throws DataConversionException {
+    public void read_missingFile_emptyResult() throws DataConversionException, IOException {
         assertFalse(read("NonExistentFile.json").isPresent());
     }
 
@@ -39,7 +39,7 @@ public class ConfigUtilTest {
     }
 
     @Test
-    public void read_fileInOrder_successfullyRead() throws DataConversionException {
+    public void read_fileInOrder_successfullyRead() throws DataConversionException, IOException {
 
         Config expected = getTypicalConfig();
 
@@ -48,13 +48,13 @@ public class ConfigUtilTest {
     }
 
     @Test
-    public void read_valuesMissingFromFile_defaultValuesUsed() throws DataConversionException {
+    public void read_valuesMissingFromFile_defaultValuesUsed() throws DataConversionException, IOException {
         Config actual = read("EmptyConfig.json").get();
         assertEquals(new Config(), actual);
     }
 
     @Test
-    public void read_extraValuesInFile_extraValuesIgnored() throws DataConversionException {
+    public void read_extraValuesInFile_extraValuesIgnored() throws DataConversionException, IOException {
         Config expected = getTypicalConfig();
         Config actual = read("ExtraValuesConfig.json").get();
 
@@ -68,7 +68,7 @@ public class ConfigUtilTest {
         return config;
     }
 
-    private Optional<Config> read(String configFileInTestDataFolder) throws DataConversionException {
+    private Optional<Config> read(String configFileInTestDataFolder) throws DataConversionException, IOException {
         Path configFilePath = addToTestDataPathIfNotNull(configFileInTestDataFolder);
         return ConfigUtil.readConfig(configFilePath);
     }

--- a/src/test/java/seedu/address/storage/JsonUserPrefsStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonUserPrefsStorageTest.java
@@ -28,13 +28,14 @@ public class JsonUserPrefsStorageTest {
         assertThrows(NullPointerException.class, () -> readUserPrefs(null));
     }
 
-    private Optional<UserPrefs> readUserPrefs(String userPrefsFileInTestDataFolder) throws DataConversionException {
+    private Optional<UserPrefs> readUserPrefs(String userPrefsFileInTestDataFolder)
+            throws DataConversionException, IOException {
         Path prefsFilePath = addToTestDataPathIfNotNull(userPrefsFileInTestDataFolder);
         return new JsonUserPrefsStorage(prefsFilePath).readUserPrefs(prefsFilePath);
     }
 
     @Test
-    public void readUserPrefs_missingFile_emptyResult() throws DataConversionException {
+    public void readUserPrefs_missingFile_emptyResult() throws DataConversionException, IOException {
         assertFalse(readUserPrefs("NonExistentFile.json").isPresent());
     }
 
@@ -50,20 +51,20 @@ public class JsonUserPrefsStorageTest {
     }
 
     @Test
-    public void readUserPrefs_fileInOrder_successfullyRead() throws DataConversionException {
+    public void readUserPrefs_fileInOrder_successfullyRead() throws DataConversionException, IOException {
         UserPrefs expected = getTypicalUserPrefs();
         UserPrefs actual = readUserPrefs("TypicalUserPref.json").get();
         assertEquals(expected, actual);
     }
 
     @Test
-    public void readUserPrefs_valuesMissingFromFile_defaultValuesUsed() throws DataConversionException {
+    public void readUserPrefs_valuesMissingFromFile_defaultValuesUsed() throws DataConversionException, IOException {
         UserPrefs actual = readUserPrefs("EmptyUserPrefs.json").get();
         assertEquals(new UserPrefs(), actual);
     }
 
     @Test
-    public void readUserPrefs_extraValuesInFile_extraValuesIgnored() throws DataConversionException {
+    public void readUserPrefs_extraValuesInFile_extraValuesIgnored() throws DataConversionException, IOException {
         UserPrefs expected = getTypicalUserPrefs();
         UserPrefs actual = readUserPrefs("ExtraValuesUserPref.json").get();
 


### PR DESCRIPTION
Fixes #167 

Alternative Approach: #191 

Classes that implements the methods,
- readAddressBook() from AddressBookStorage interface
- readUserPrefs() from UserPrefsStorage interface does not actually throw any IOException as such exceptions are caught within the method and is being treated as DataConversionException which may not be the case.

All IOException are caught by JsonUtil.readJsonFile() which is called by classes implementing these methods.

This method also causes ConfigUtil.readConfig() to not throw IOExceptions when handling actual IOExceptions that is not caused by a conversion error.

This causes the wrong log messages to be logged when an actual IOException occur.

Let's
- decouple actual conversion errors from IOExceptions and restore functionality to the catch blocks in MainApp.java that handles IOExceptions.
- add catch blocks to handle IOException when reading config files

---

We can see the effect of the change below when reading files that does not have sufficient read permissions:

![image](https://github.com/se-edu/addressbook-level3/assets/4567895/19810d22-00db-4e70-bc9c-5f4eba137791)

---

Right now, actual IOExceptions (not conversion errors) are still being handled like conversion errors where a blank/default save file is used instead. 
I would prefer to show some form of warning then exit the application instead. However, this might require additional changes to UI behavior so I left it as such for now. 
