### PR TITLE
[#98] Space character dropped at line break when converting to PDF 

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -63,6 +63,7 @@ AddressBook Level 3 (AB3) is a **desktop app for managing contacts, optimized fo
 * Extraneous parameters for commands that do not take in parameters (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>
   e.g. if the command specifies `help 123`, it will be interpreted as `help`.
 
+* If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines as space characters surrounding line-breaks may be omitted when copied over to the application.
 </div>
 
 ### Viewing help : `help`


### PR DESCRIPTION
Fixes #98 

In the pdf version of UG, commands that span across more than one line when copied-pasted to the application will drop the line-break. As line-breaks will usually be formatted at spaces when converting to pdf, this will cause the space in command to be dropped when pasting into the application.

Therefore, let's update the UG to inform the users about this behavior.