### PR TITLE
Fix not visible help menu / bump javafx version (to ver 15)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ task coverage(type: JacocoReport) {
 
 dependencies {
     String jUnitVersion = '5.4.0'
-    String javaFxVersion = '11.0.2'
+    String javaFxVersion = '15.0.1'
 
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'win'
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'mac'


### PR DESCRIPTION
Fixes #193 

Launching the application on Linux distributions using KDE as the desktop manager resulted in the window not being visible when no minimum window size was set. The problem seems to be specific to the KDE Plasma graphical desktop environment. This has caused the help menu to be not visible on such platforms.

Manual testing indicates that bumping the JavaFX version to 13 or higher resolves the issue. Since version 16 will log a warning with the current project configuration, let's bump the JavaFX version to 15.

---

However, ver 15 is not LTS anymore and ver 11 is approaching its EOL. The next LTS version is ver 17 which will log a warning for not using a modular application.

There was some investigation into converting the project to modular version here but it's not very effective/useful. ([summary](https://github.com/se-edu/addressbook-level3/issues/108#issuecomment-1595777510))

---

You can find an alternative PR that explores using a log to inform the user to ignore the warning message in #199 