### PR TITLE
Standardize #equals(Object) formatting

### DIFF
--- a/docs/tutorials/AddRemark.md
+++ b/docs/tutorials/AddRemark.md
@@ -118,7 +118,6 @@ public class RemarkCommand extends Command {
 
     @Override
     public boolean equals(Object other) {
-        // short circuit if same object
         if (other == this) {
             return true;
         }
@@ -128,7 +127,6 @@ public class RemarkCommand extends Command {
             return false;
         }
 
-        // state check
         RemarkCommand e = (RemarkCommand) other;
         return index.equals(e.index)
                 && remark.equals(e.remark);

--- a/src/main/java/seedu/address/AppParameters.java
+++ b/src/main/java/seedu/address/AppParameters.java
@@ -50,12 +50,13 @@ public class AppParameters {
             return true;
         }
 
+        // instanceof handles nulls
         if (!(other instanceof AppParameters)) {
             return false;
         }
 
         AppParameters otherAppParameters = (AppParameters) other;
-        return Objects.equals(getConfigPath(), otherAppParameters.getConfigPath());
+        return Objects.equals(configPath, otherAppParameters.configPath);
     }
 
     @Override

--- a/src/main/java/seedu/address/commons/core/Config.java
+++ b/src/main/java/seedu/address/commons/core/Config.java
@@ -39,14 +39,15 @@ public class Config {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof Config)) { //this handles null as well.
+
+        // instanceof handles nulls
+        if (!(other instanceof Config)) {
             return false;
         }
 
-        Config o = (Config) other;
-
-        return Objects.equals(logLevel, o.logLevel)
-                && Objects.equals(userPrefsFilePath, o.userPrefsFilePath);
+        Config otherConfig = (Config) other;
+        return Objects.equals(logLevel, otherConfig.logLevel)
+                && Objects.equals(userPrefsFilePath, otherConfig.userPrefsFilePath);
     }
 
     @Override

--- a/src/main/java/seedu/address/commons/core/GuiSettings.java
+++ b/src/main/java/seedu/address/commons/core/GuiSettings.java
@@ -54,15 +54,16 @@ public class GuiSettings implements Serializable {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof GuiSettings)) { //this handles null as well.
+
+        // instanceof handles nulls
+        if (!(other instanceof GuiSettings)) {
             return false;
         }
 
-        GuiSettings o = (GuiSettings) other;
-
-        return windowWidth == o.windowWidth
-                && windowHeight == o.windowHeight
-                && Objects.equals(windowCoordinates, o.windowCoordinates);
+        GuiSettings otherGuiSettings = (GuiSettings) other;
+        return windowWidth == otherGuiSettings.windowWidth
+                && windowHeight == otherGuiSettings.windowHeight
+                && Objects.equals(windowCoordinates, otherGuiSettings.windowCoordinates);
     }
 
     @Override

--- a/src/main/java/seedu/address/commons/core/Version.java
+++ b/src/main/java/seedu/address/commons/core/Version.java
@@ -93,16 +93,21 @@ public class Version implements Comparable<Version> {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
         }
-        if (!(obj instanceof Version)) {
-            return false;
-        }
-        final Version other = (Version) obj;
 
-        return compareTo(other) == 0;
+        // instanceof handles nulls
+        if (!(other instanceof Version)) {
+            return false;
+        }
+
+        Version otherVersion = (Version) other;
+        return major == otherVersion.major
+                && minor == otherVersion.minor
+                && patch == otherVersion.patch
+                && isEarlyAccess == otherVersion.isEarlyAccess;
     }
 
     @Override

--- a/src/main/java/seedu/address/commons/core/index/Index.java
+++ b/src/main/java/seedu/address/commons/core/index/Index.java
@@ -49,9 +49,17 @@ public class Index {
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof Index // instanceof handles nulls
-                && zeroBasedIndex == ((Index) other).zeroBasedIndex); // state check
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Index)) {
+            return false;
+        }
+
+        Index otherIndex = (Index) other;
+        return zeroBasedIndex == otherIndex.zeroBasedIndex;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -62,9 +62,17 @@ public class AddCommand extends Command {
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof AddCommand // instanceof handles nulls
-                && toAdd.equals(((AddCommand) other).toAdd));
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AddCommand)) {
+            return false;
+        }
+
+        AddCommand otherAddCommand = (AddCommand) other;
+        return toAdd.equals(otherAddCommand.toAdd);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -47,9 +47,17 @@ public class DeleteCommand extends Command {
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof DeleteCommand // instanceof handles nulls
-                && targetIndex.equals(((DeleteCommand) other).targetIndex)); // state check
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof DeleteCommand)) {
+            return false;
+        }
+
+        DeleteCommand otherDeleteCommand = (DeleteCommand) other;
+        return targetIndex.equals(otherDeleteCommand.targetIndex);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -11,6 +11,7 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -105,7 +106,6 @@ public class EditCommand extends Command {
 
     @Override
     public boolean equals(Object other) {
-        // short circuit if same object
         if (other == this) {
             return true;
         }
@@ -115,10 +115,9 @@ public class EditCommand extends Command {
             return false;
         }
 
-        // state check
-        EditCommand e = (EditCommand) other;
-        return index.equals(e.index)
-                && editPersonDescriptor.equals(e.editPersonDescriptor);
+        EditCommand otherEditCommand = (EditCommand) other;
+        return index.equals(otherEditCommand.index)
+                && editPersonDescriptor.equals(otherEditCommand.editPersonDescriptor);
     }
 
     @Override
@@ -212,7 +211,6 @@ public class EditCommand extends Command {
 
         @Override
         public boolean equals(Object other) {
-            // short circuit if same object
             if (other == this) {
                 return true;
             }
@@ -222,14 +220,12 @@ public class EditCommand extends Command {
                 return false;
             }
 
-            // state check
-            EditPersonDescriptor e = (EditPersonDescriptor) other;
-
-            return getName().equals(e.getName())
-                    && getPhone().equals(e.getPhone())
-                    && getEmail().equals(e.getEmail())
-                    && getAddress().equals(e.getAddress())
-                    && getTags().equals(e.getTags());
+            EditPersonDescriptor otherEditPersonDescriptor = (EditPersonDescriptor) other;
+            return Objects.equals(name, otherEditPersonDescriptor.name)
+                    && Objects.equals(phone, otherEditPersonDescriptor.phone)
+                    && Objects.equals(email, otherEditPersonDescriptor.email)
+                    && Objects.equals(address, otherEditPersonDescriptor.address)
+                    && Objects.equals(tags, otherEditPersonDescriptor.tags);
         }
 
         @Override

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -36,9 +36,17 @@ public class FindCommand extends Command {
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof FindCommand // instanceof handles nulls
-                && predicate.equals(((FindCommand) other).predicate)); // state check
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof FindCommand)) {
+            return false;
+        }
+
+        FindCommand otherFindCommand = (FindCommand) other;
+        return predicate.equals(otherFindCommand.predicate);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/Prefix.java
+++ b/src/main/java/seedu/address/logic/parser/Prefix.java
@@ -26,15 +26,17 @@ public class Prefix {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (!(obj instanceof Prefix)) {
-            return false;
-        }
-        if (obj == this) {
+    public boolean equals(Object other) {
+        if (other == this) {
             return true;
         }
 
-        Prefix otherPrefix = (Prefix) obj;
-        return otherPrefix.getPrefix().equals(getPrefix());
+        // instanceof handles nulls
+        if (!(other instanceof Prefix)) {
+            return false;
+        }
+
+        Prefix otherPrefix = (Prefix) other;
+        return prefix.equals(otherPrefix.prefix);
     }
 }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -110,9 +110,17 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof AddressBook // instanceof handles nulls
-                && persons.equals(((AddressBook) other).persons));
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AddressBook)) {
+            return false;
+        }
+
+        AddressBook otherAddressBook = (AddressBook) other;
+        return persons.equals(otherAddressBook.persons);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -129,22 +129,20 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        // short circuit if same object
-        if (obj == this) {
+    public boolean equals(Object other) {
+        if (other == this) {
             return true;
         }
 
         // instanceof handles nulls
-        if (!(obj instanceof ModelManager)) {
+        if (!(other instanceof ModelManager)) {
             return false;
         }
 
-        // state check
-        ModelManager other = (ModelManager) obj;
-        return addressBook.equals(other.addressBook)
-                && userPrefs.equals(other.userPrefs)
-                && filteredPersons.equals(other.filteredPersons);
+        ModelManager otherModelManager = (ModelManager) other;
+        return addressBook.equals(otherModelManager.addressBook)
+                && userPrefs.equals(otherModelManager.userPrefs)
+                && filteredPersons.equals(otherModelManager.filteredPersons);
     }
 
 }

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -61,14 +61,15 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof UserPrefs)) { //this handles null as well.
+
+        // instanceof handles nulls
+        if (!(other instanceof UserPrefs)) {
             return false;
         }
 
-        UserPrefs o = (UserPrefs) other;
-
-        return guiSettings.equals(o.guiSettings)
-                && addressBookFilePath.equals(o.addressBookFilePath);
+        UserPrefs otherUserPrefs = (UserPrefs) other;
+        return guiSettings.equals(otherUserPrefs.guiSettings)
+                && addressBookFilePath.equals(otherUserPrefs.addressBookFilePath);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Address.java
+++ b/src/main/java/seedu/address/model/person/Address.java
@@ -44,9 +44,17 @@ public class Address {
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof Address // instanceof handles nulls
-                && value.equals(((Address) other).value)); // state check
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Address)) {
+            return false;
+        }
+
+        Address otherAddress = (Address) other;
+        return value.equals(otherAddress.value);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -58,9 +58,17 @@ public class Email {
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof Email // instanceof handles nulls
-                && value.equals(((Email) other).value)); // state check
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Email)) {
+            return false;
+        }
+
+        Email otherEmail = (Email) other;
+        return value.equals(otherEmail.value);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -46,9 +46,17 @@ public class Name {
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof Name // instanceof handles nulls
-                && fullName.equals(((Name) other).fullName)); // state check
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Name)) {
+            return false;
+        }
+
+        Name otherName = (Name) other;
+        return fullName.equals(otherName.fullName);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -24,9 +24,17 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof NameContainsKeywordsPredicate // instanceof handles nulls
-                && keywords.equals(((NameContainsKeywordsPredicate) other).keywords)); // state check
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof NameContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        NameContainsKeywordsPredicate otherNameContainsKeywordsPredicate = (NameContainsKeywordsPredicate) other;
+        return keywords.equals(otherNameContainsKeywordsPredicate.keywords);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -84,16 +84,17 @@ public class Person {
             return true;
         }
 
+        // instanceof handles nulls
         if (!(other instanceof Person)) {
             return false;
         }
 
         Person otherPerson = (Person) other;
-        return otherPerson.getName().equals(getName())
-                && otherPerson.getPhone().equals(getPhone())
-                && otherPerson.getEmail().equals(getEmail())
-                && otherPerson.getAddress().equals(getAddress())
-                && otherPerson.getTags().equals(getTags());
+        return name.equals(otherPerson.name)
+                && phone.equals(otherPerson.phone)
+                && email.equals(otherPerson.email)
+                && address.equals(otherPerson.address)
+                && tags.equals(otherPerson.tags);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -40,9 +40,17 @@ public class Phone {
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof Phone // instanceof handles nulls
-                && value.equals(((Phone) other).value)); // state check
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Phone)) {
+            return false;
+        }
+
+        Phone otherPhone = (Phone) other;
+        return value.equals(otherPhone.value);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -111,9 +111,17 @@ public class UniquePersonList implements Iterable<Person> {
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof UniquePersonList // instanceof handles nulls
-                        && internalList.equals(((UniquePersonList) other).internalList));
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof UniquePersonList)) {
+            return false;
+        }
+
+        UniquePersonList otherUniquePersonList = (UniquePersonList) other;
+        return internalList.equals(otherUniquePersonList.internalList);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -34,9 +34,17 @@ public class Tag {
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof Tag // instanceof handles nulls
-                && tagName.equals(((Tag) other).tagName)); // state check
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Tag)) {
+            return false;
+        }
+
+        Tag otherTag = (Tag) other;
+        return tagName.equals(otherTag.tagName);
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -59,7 +59,6 @@ public class PersonCard extends UiPart<Region> {
 
     @Override
     public boolean equals(Object other) {
-        // short circuit if same object
         if (other == this) {
             return true;
         }
@@ -69,7 +68,6 @@ public class PersonCard extends UiPart<Region> {
             return false;
         }
 
-        // state check
         PersonCard card = (PersonCard) other;
         return id.getText().equals(card.id.getText())
                 && person.equals(card.person);

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -56,20 +56,4 @@ public class PersonCard extends UiPart<Region> {
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
     }
-
-    @Override
-    public boolean equals(Object other) {
-        if (other == this) {
-            return true;
-        }
-
-        // instanceof handles nulls
-        if (!(other instanceof PersonCard)) {
-            return false;
-        }
-
-        PersonCard card = (PersonCard) other;
-        return id.getText().equals(card.id.getText())
-                && person.equals(card.person);
-    }
 }

--- a/src/test/java/seedu/address/AppParametersTest.java
+++ b/src/test/java/seedu/address/AppParametersTest.java
@@ -1,6 +1,8 @@
 package seedu.address;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Paths;
 import java.util.Collections;
@@ -42,6 +44,28 @@ public class AppParametersTest {
         AppParameters appParameters = new AppParameters();
         String expected = AppParameters.class.getCanonicalName() + "{configPath=" + appParameters.getConfigPath() + "}";
         assertEquals(expected, appParameters.toString());
+    }
+
+    @Test
+    public void equals() {
+        AppParameters appParameters = new AppParameters();
+
+        // same values -> returns true
+        assertTrue(appParameters.equals(new AppParameters()));
+
+        // same object -> returns true
+        assertTrue(appParameters.equals(appParameters));
+
+        // null -> returns false
+        assertFalse(appParameters.equals(null));
+
+        // different types -> returns false
+        assertFalse(appParameters.equals(5.0f));
+
+        // different config path -> returns false
+        AppParameters otherAppParameters = new AppParameters();
+        otherAppParameters.setConfigPath(Paths.get("configPath"));
+        assertFalse(appParameters.equals(otherAppParameters));
     }
 
     private static class ParametersStub extends Application.Parameters {

--- a/src/test/java/seedu/address/model/person/AddressTest.java
+++ b/src/test/java/seedu/address/model/person/AddressTest.java
@@ -33,4 +33,24 @@ public class AddressTest {
         assertTrue(Address.isValidAddress("-")); // one character
         assertTrue(Address.isValidAddress("Leng Inc; 1234 Market St; San Francisco CA 2349879; USA")); // long address
     }
+
+    @Test
+    public void equals() {
+        Address address = new Address("Valid Address");
+
+        // same values -> returns true
+        assertTrue(address.equals(new Address("Valid Address")));
+
+        // same object -> returns true
+        assertTrue(address.equals(address));
+
+        // null -> returns false
+        assertFalse(address.equals(null));
+
+        // different types -> returns false
+        assertFalse(address.equals(5.0f));
+
+        // different values -> returns false
+        assertFalse(address.equals(new Address("Other Valid Address")));
+    }
 }

--- a/src/test/java/seedu/address/model/person/EmailTest.java
+++ b/src/test/java/seedu/address/model/person/EmailTest.java
@@ -65,4 +65,24 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part
         assertTrue(Email.isValidEmail("e1234567@u.nus.edu")); // more than one period in domain
     }
+
+    @Test
+    public void equals() {
+        Email email = new Email("valid@email");
+
+        // same values -> returns true
+        assertTrue(email.equals(new Email("valid@email")));
+
+        // same object -> returns true
+        assertTrue(email.equals(email));
+
+        // null -> returns false
+        assertFalse(email.equals(null));
+
+        // different types -> returns false
+        assertFalse(email.equals(5.0f));
+
+        // different values -> returns false
+        assertFalse(email.equals(new Email("other.valid@email")));
+    }
 }

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -37,4 +37,24 @@ public class NameTest {
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
         assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
     }
+
+    @Test
+    public void equals() {
+        Name name = new Name("Valid Name");
+
+        // same values -> returns true
+        assertTrue(name.equals(new Name("Valid Name")));
+
+        // same object -> returns true
+        assertTrue(name.equals(name));
+
+        // null -> returns false
+        assertFalse(name.equals(null));
+
+        // different types -> returns false
+        assertFalse(name.equals(5.0f));
+
+        // different values -> returns false
+        assertFalse(name.equals(new Name("Other Valid Name")));
+    }
 }

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -37,4 +37,24 @@ public class PhoneTest {
         assertTrue(Phone.isValidPhone("93121534"));
         assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers
     }
+
+    @Test
+    public void equals() {
+        Phone phone = new Phone("999");
+
+        // same values -> returns true
+        assertTrue(phone.equals(new Phone("999")));
+
+        // same object -> returns true
+        assertTrue(phone.equals(phone));
+
+        // null -> returns false
+        assertFalse(phone.equals(null));
+
+        // different types -> returns false
+        assertFalse(phone.equals(5.0f));
+
+        // different values -> returns false
+        assertFalse(phone.equals(new Phone("995")));
+    }
 }

--- a/src/test/java/seedu/address/ui/TestFxmlObject.java
+++ b/src/test/java/seedu/address/ui/TestFxmlObject.java
@@ -1,5 +1,7 @@
 package seedu.address.ui;
 
+import java.util.Objects;
+
 import javafx.beans.DefaultProperty;
 
 /**
@@ -27,9 +29,17 @@ public class TestFxmlObject {
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof TestFxmlObject // instanceof handles nulls
-                        && text.equals(((TestFxmlObject) other).getText()));
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof TestFxmlObject)) {
+            return false;
+        }
+
+        TestFxmlObject otherTestFxmlObject = (TestFxmlObject) other;
+        return Objects.equals(text, otherTestFxmlObject.text);
     }
 
 }


### PR DESCRIPTION
Partially adapted from [AB4#973](https://github.com/se-edu/addressbook-level4/pull/973/)

To go along with some of the equality checks, some methods and constructors are reevaluated to follow defensive programming by adding suitable null checks. 

AB3 has all sorts of #equals(Object) flavors. Some of them are formatted
with nested logic comparison while some contain unnecessary code. It will
enable better readability for others if they were to be standardized to
follow a similar format.

Generally, #equals(Object) should:
* Name the parameter 'other' of the method
* Check if other == this
* Check if other is an instance of this class + comment for null check
* Set a temporary variable otherCLASSNAME
* Perform other related internal checks.

Should the internal variable be nullable, we should use
Objects.equals(var, var2) to compare between the 2.

Doing the above should improve the clarity and ease of
use of #equals(Object) methods.