### PR TITLE
Upgrade JavaFX to ver 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ task coverage(type: JacocoReport) {
 
 dependencies {
     String jUnitVersion = '5.4.0'
-    String javaFxVersion = '11.0.2'
+    String javaFxVersion = '17.0.7'
 
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'win'
     implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'mac'

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -424,7 +424,7 @@
     <module name="MissingJavadocMethodCheck">
       <property name="minLineCount" value="1"/>
       <property name="allowMissingPropertyJavadoc" value="true"/>
-      <property name="ignoreMethodNamesRegex" value="(set.*|get.*)"/>
+      <property name="ignoreMethodNamesRegex" value="(set.*|get.*|main)"/>
     </module>
 
     <!-- Checks that every public class, enumeration and interface has a header comment. -->

--- a/src/main/java/seedu/address/Main.java
+++ b/src/main/java/seedu/address/Main.java
@@ -1,6 +1,9 @@
 package seedu.address;
 
+import java.util.logging.Logger;
+
 import javafx.application.Application;
+import seedu.address.commons.core.LogsCenter;
 
 /**
  * The main entry point to the application.
@@ -19,7 +22,20 @@ import javafx.application.Application;
  * to be the entry point of the application, we avoid this issue.
  */
 public class Main {
+    private static Logger logger = LogsCenter.getLogger(Main.class);
+
     public static void main(String[] args) {
+
+        // As per https://github.com/openjdk/jfx/blob/master/doc-files/release-notes-16.md
+        // JavaFX 16 (or later) runtime logs a warning at startup if JavaFX classes are loaded from
+        // the classpath instead of a module.
+        // Our application does not use Java modules yet. Even if it did, modules are ignored when
+        // packed into a FAT Jar file (as we do), which means this warning will persist even then.
+        // The warning however, can be safely ignored. Thus, the following log informs
+        // the user (if looking at the log output) that the said warning appearing in the log
+        // can be ignored.
+
+        logger.warning("The warning about Unsupported JavaFX configuration below can be ignored.");
         Application.launch(MainApp.class, args);
     }
 }

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -3,7 +3,7 @@
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.StackPane?>
 
-<StackPane styleClass="stack-pane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<StackPane styleClass="stack-pane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <TextField fx:id="commandTextField" onAction="#handleCommandEntered" promptText="Enter command here..."/>
 </StackPane>
 

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -9,7 +9,7 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.stage.Stage?>
 
-<fx:root resizable="false" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root resizable="false" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/help_icon.png" />
   </icons>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -11,7 +11,7 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
-<fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
+<fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
          title="Address App" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
   <icons>
     <Image url="@/images/address_book_32.png" />

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -9,7 +9,7 @@
 <?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />

--- a/src/main/resources/view/PersonListPanel.fxml
+++ b/src/main/resources/view/PersonListPanel.fxml
@@ -3,6 +3,6 @@
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <ListView fx:id="personListView" VBox.vgrow="ALWAYS" />
 </VBox>

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -3,7 +3,7 @@
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.layout.StackPane?>
 
-<StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/8"
+<StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/17"
     xmlns:fx="http://javafx.com/fxml/1">
   <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display"/>
 </StackPane>

--- a/src/main/resources/view/StatusBarFooter.fxml
+++ b/src/main/resources/view/StatusBarFooter.fxml
@@ -4,7 +4,7 @@
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 
-<GridPane styleClass="status-bar" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<GridPane styleClass="status-bar" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <columnConstraints>
     <ColumnConstraints hgrow="SOMETIMES" minWidth="10" />
   </columnConstraints>

--- a/src/test/resources/view/UiPartTest/validFileWithFxRoot.fxml
+++ b/src/test/resources/view/UiPartTest/validFileWithFxRoot.fxml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<fx:root type="seedu.address.ui.TestFxmlObject" xmlns="http://javafx.com/javafx"
-            xmlns:fx="http://javafx.com/fxml">
+<fx:root type="seedu.address.ui.TestFxmlObject" xmlns="http://javafx.com/javafx/17"
+        xmlns:fx="http://javafx.com/fxml/1">
     <text>Hello World!</text>
 </fx:root>


### PR DESCRIPTION
Fixes #193 
Fixes #108 

This is an alternative PR to #196 which explores adding an extra log message to inform the user to ignore the warning message while upgrading to an LTS version.

The application uses JavaFX 11 which is reaching its EOL in September
2023. Thus it is better to upgrade JavaFX to the next LTS version which is version 17.

However, after version 16, JavaFX now throws a warning when JavaFX modules are loaded from the classpath. As there is currently no plan to migrate to using Modules in AB3, let's include an additional log message to inform the users to ignore the warning message.

<img width="671" alt="image" src="https://github.com/se-edu/addressbook-level3/assets/4567895/fca77461-665b-4c7c-a316-576a8dcc5d9d">
<img width="683" alt="image" src="https://github.com/se-edu/addressbook-level3/assets/4567895/cdb75d73-034b-4078-a05b-f6bd18f52750">
