### PR TITLE
[#212] Remove extra white-space in PersonListCard

### DIFF
--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -18,7 +18,7 @@
       <padding>
         <Insets top="5" right="5" bottom="5" left="15" />
       </padding>
-      <HBox spacing="5" alignment="CENTER_LEFT">
+      <HBox spacing="0.5" alignment="CENTER_LEFT">
         <Label fx:id="id" styleClass="cell_big_label">
           <minWidth>
             <!-- Ensures that the label text is never truncated -->


### PR DESCRIPTION
Fixes #212 

Reduced spacing between the index and name to remove the extra white-space by adjusting spacing of Hbox

Before:
<img width="740" alt="image" src="https://github.com/se-edu/addressbook-level3/assets/73015364/fc46f14c-e863-4664-b5b7-cc026bbcf718">

After:
<img width="740" alt="Screenshot 2024-06-05 at 4 48 49 PM" src="https://github.com/se-edu/addressbook-level3/assets/73015364/12b460fb-707b-4902-9268-a789df6950b1">
