### PR TITLE
[#231] Fix typo in User Guide

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -66,7 +66,7 @@ AddressBook Level 3 (AB3) is a **desktop app for managing contacts, optimized fo
 
 ### Viewing help : `help`
 
-Shows a message explaning how to access the help page.
+Shows a message explaining how to access the help page.
 
 ![help message](images/helpMessage.png)
 


### PR DESCRIPTION
Fixes #231 

User Guide: fix typo explaning -> explaining

The UserGuide.md file contains a typo: "explaning" instead of "explaining".

Let's fix this typo to improve documentation accuracy and readability.