### PR TITLE
Update gradle checkstyle version to 11.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 }
 
 checkstyle {
-    toolVersion = '10.2'
+    toolVersion = '11.0.0'
 }
 
 test {


### PR DESCRIPTION
Closes #237 

Upgraded Checkstyle version to `11.0.0`

`11.0.0` is stable compatible with all JDK `17` and above. 
Tested and observed that the new checkstyle version works without issues, with the current `checkstyle.xml`.