### PR TITLE
build: bump Checkstyle to 10.25.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 }
 
 checkstyle {
-    toolVersion = '10.2'
+    toolVersion = '10.25.0'
 }
 
 test {


### PR DESCRIPTION
- Upgraded from Checkstyle 10.2 to 10.25.0
- Maintains compatibility with Java 17
- No code violations introduced by the upgrade
- All existing rules remain compatible