### PR TITLE
Remove redundant checkout steps from CI workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,14 +13,6 @@ jobs:
       - name: Set up repository
         uses: actions/checkout@v7
 
-      - name: Set up repository
-        uses: actions/checkout@v7
-        with:
-          ref: master
-
-      - name: Merge to master
-        run: git checkout --progress --force ${{ github.sha }}
-
       - name: Run repository-wide tests
         if: runner.os == 'Linux'
         working-directory:  ${{ github.workspace }}/.github


### PR DESCRIPTION
## What changed

Removes two steps from `.github/workflows/gradle.yml`: the second `Set up repository` checkout (`ref: master`) and the `Merge to master` step (`git checkout --progress --force ${{ github.sha }}`).

## Why

These steps date back to the Travis CI → GitHub Actions migration (0be83b24, May 2020) and were meant to test the code as merged into master. The plain `actions/checkout` step already does that: on `pull_request` events it checks out GitHub's auto-generated merge commit (`refs/pull/N/merge`, which is what `github.sha` points to), so the removed steps only re-checked-out the commit already in the working tree. Their sole side effect was an unused local `master` branch.

Removing them also fixes a latent issue: the hard-coded `ref: master` fails in forks whose default branch has a different name.

## Notes for reviewers

- The two steps are only removable **as a pair** — dropping just `Merge to master` would leave HEAD on `master`, silently testing the wrong code. This PR removes both.
- Behavior was verified against the live run log of #268, where the first checkout runs `git checkout --progress --force refs/remotes/pull/268/merge` — identical to what the removed steps re-derived.
- The redundancy has confused students before; see the discussion in nus-cs2103-AY2425S2/forum#153 (about se-edu/duke's copy of the same workflow).
- se-edu/duke's `full-template` branch carries the same vestigial trio and could get a matching cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)